### PR TITLE
Add Jest testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+coverage/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ This project has been converted to use the React framework with Vite.
    npm run build
    ```
 
+## Testing
+
+Unit tests use Jest and React Testing Library.
+
+Run the test suite with:
+
+```bash
+npm test
+```
+
 ## Features
 
 - Manage owned and wishlist DVD lists.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['js', 'jsx'],
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect']
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -13,6 +14,13 @@
   },
   "devDependencies": {
     "vite": "^5.0.0",
-    "@vitejs/plugin-react": "^4.0.0"
+    "@vitejs/plugin-react": "^4.0.0",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.24.5"
   }
 }

--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { highlightMatch } from '../utils';
 
 export default function ListSection({
   title,
@@ -29,11 +30,6 @@ export default function ListSection({
     .map((t, i) => ({ t, i }))
     .filter((o) => !normFilter || o.t.toLowerCase().includes(normFilter));
 
-  const highlightMatch = (text) => {
-    if (!normFilter) return text;
-    const regex = new RegExp(`(${normFilter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
-    return text.replace(regex, '<span class="match-highlight">$1</span>');
-  };
 
   return (
     <div className="list-section">
@@ -49,7 +45,7 @@ export default function ListSection({
               key={o.i}
               className={`${title.toLowerCase()}-item`}
               onClick={(e) => onItemClick(o.i, e.altKey)}
-              dangerouslySetInnerHTML={{ __html: highlightMatch(o.t) }}
+              dangerouslySetInnerHTML={{ __html: highlightMatch(o.t, normFilter) }}
             />
           ))
         )}

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ListSection from './ListSection';
+
+describe('ListSection', () => {
+  test('calls onAdd when Add button clicked', () => {
+    const onAdd = jest.fn();
+    const { getByPlaceholderText, getByText } = render(
+      <ListSection
+        title="Wishlist"
+        items={[]}
+        onItemClick={() => {}}
+        onAdd={onAdd}
+        placeholder="Add item"
+        filter=""
+      />
+    );
+    fireEvent.change(getByPlaceholderText('Add item'), { target: { value: 'DVD' } });
+    fireEvent.click(getByText('Add'));
+    expect(onAdd).toHaveBeenCalledWith('DVD');
+  });
+
+  test('filters items based on filter prop', () => {
+    const { queryByText } = render(
+      <ListSection
+        title="Wishlist"
+        items={['Star Wars', 'Toy Story']}
+        onItemClick={() => {}}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter="toy"
+      />
+    );
+    expect(queryByText('Star Wars')).toBeNull();
+    expect(queryByText('Toy Story')).toBeInTheDocument();
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,5 @@
+export function highlightMatch(text, filter) {
+  if (!filter) return text;
+  const regex = new RegExp(`(${filter.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`, 'gi');
+  return text.replace(regex, '<span class="match-highlight">$1</span>');
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,9 @@
+import { highlightMatch } from './utils';
+
+test('highlightMatch returns text when filter is empty', () => {
+  expect(highlightMatch('Hello', '')).toBe('Hello');
+});
+
+test('highlightMatch wraps matches', () => {
+  expect(highlightMatch('Hello', 'he')).toBe('<span class="match-highlight">He</span>llo');
+});


### PR DESCRIPTION
## Summary
- set up Jest with React Testing Library
- create highlightMatch helper
- update ListSection to use helper
- add basic unit tests
- document how to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4a8da0d0832e9be68e97e2400a84