### PR TITLE
Add move button for list items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,8 +163,8 @@ export default function App() {
     <div>
       <h1>DVD Collection Tracker</h1>
       <p className="search-info">
-        Click a title to move it between lists. Use the Delete button to remove
-        it.
+        Use the Move button to transfer a title between lists. Use Delete to
+        remove it.
       </p>
       <div className="search-container">
         <input
@@ -190,7 +190,7 @@ export default function App() {
       <ListSection
         title="Wishlist"
         items={wishlist}
-        onItemClick={moveFromWishlist}
+        onMove={moveFromWishlist}
         onDelete={deleteFromWishlist}
         onAdd={addWishlist}
         placeholder="Add to wishlist"
@@ -199,7 +199,7 @@ export default function App() {
       <ListSection
         title="Owned"
         items={owned}
-        onItemClick={moveFromOwned}
+        onMove={moveFromOwned}
         onDelete={deleteFromOwned}
         onAdd={addOwned}
         placeholder="Add to owned"

--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -4,7 +4,7 @@ import { highlightMatch } from '../utils';
 export default function ListSection({
   title,
   items,
-  onItemClick,
+  onMove = () => {},
   onAdd,
   onDelete = () => {},
   placeholder,
@@ -45,13 +45,22 @@ export default function ListSection({
             <li
               key={o.i}
               className={`${title.toLowerCase()}-item`}
-              onClick={() => onItemClick(o.i)}
             >
               <span
                 dangerouslySetInnerHTML={{
                   __html: highlightMatch(o.t, normFilter),
                 }}
               />
+              <button
+                className="move-button"
+                aria-label="Move"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMove(o.i);
+                }}
+              >
+                ➡️
+              </button>
               <button
                 className="delete-button"
                 aria-label="Delete"

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -12,7 +12,7 @@ describe.skip('ListSection', () => {
       <ListSection
         title="Wishlist"
         items={[]}
-        onItemClick={() => {}}
+        onMove={() => {}}
         onDelete={() => {}}
         onAdd={onAdd}
         placeholder="Add item"
@@ -29,7 +29,7 @@ describe.skip('ListSection', () => {
       <ListSection
         title="Wishlist"
         items={['Star Wars', 'Toy Story']}
-        onItemClick={() => {}}
+        onMove={() => {}}
         onDelete={() => {}}
         onAdd={() => {}}
         placeholder="Add item"

--- a/src/styles.css
+++ b/src/styles.css
@@ -156,6 +156,17 @@ li:hover {
 .delete-button:hover {
   color: #fff;
 }
+.move-button {
+  background: transparent;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  padding: 0 0.3rem;
+  float: right;
+}
+.move-button:hover {
+  color: #fff;
+}
 .wishlist-item {
   border-left: 3px solid var(--wishlist);
   padding-left: 0.8rem;
@@ -212,4 +223,8 @@ footer p {
   h1 { font-size: 1.3rem; }
   .list-section h2 { font-size: 1.1rem; }
   li { padding: 0.5rem 0.3rem; font-size: 0.9rem; }
+  .move-button,
+  .delete-button {
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- move items using a dedicated Move button
- clarify move/delete instructions
- style new Move buttons for desktop and mobile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d58d07f60832e894954b2f26c9151