### PR TITLE
Restore jsdom environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  // Use the Node environment since jsdom is not available
-  testEnvironment: 'node',
+  // Run tests in a browser-like environment
+  testEnvironment: 'jsdom',
   moduleFileExtensions: ['js', 'jsx'],
   transform: {
     '^.+\\.(js|jsx)$': 'babel-jest'

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders heading', () => {
+  render(<App />);
+  expect(screen.getByText(/DVD Collection Tracker/i)).toBeInTheDocument();
+});

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import ListSection from './ListSection';
 
-// Skipping these tests because the project does not include a DOM environment
-// such as jsdom. They rely on DOM APIs which are unavailable in this
-// restricted environment.
-describe.skip('ListSection', () => {
+describe('ListSection', () => {
   test('calls onAdd when Add button clicked', () => {
     const onAdd = jest.fn();
     const { getByPlaceholderText, getByText } = render(


### PR DESCRIPTION
## Summary
- switch Jest environment back to `jsdom`
- enable `ListSection` tests
- add a simple test for `App`

## Testing
- `npm install --silent` *(fails: registry access blocked)*
- `npm test -- -i` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d653aafac832ea559da9eb6eb87bc