### PR TITLE
Add missing ListSection tests and confirmation tests

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import App from './App';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('moving a wishlist item shows confirmation and moves item after confirming', async () => {
+  localStorage.setItem('dvdData', JSON.stringify({ owned: [], wishlist: ['Movie'] }));
+  const { findByText, queryByText, getAllByLabelText } = render(<App />);
+
+  // wait for item to appear from localStorage
+  await findByText('Movie');
+
+  fireEvent.click(getAllByLabelText('Move')[0]);
+  expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Yes'));
+
+  await findByText('Movie');
+  expect(screen.queryByText('Move this title to owned?')).toBeNull();
+
+  // item should now be under Owned section and not under Wishlist
+  const ownedItems = document.querySelectorAll('.owned-item');
+  expect(ownedItems.length).toBe(1);
+  expect(queryByText('Movie')).not.toBeNull();
+  const wishlistItems = document.querySelectorAll('.wishlist-item');
+  expect(wishlistItems.length).toBe(0);
+});
+
+test('deleting a wishlist item confirms and removes it', async () => {
+  localStorage.setItem('dvdData', JSON.stringify({ owned: [], wishlist: ['Trash'] }));
+  const { findByText, queryByText, getAllByLabelText } = render(<App />);
+
+  await findByText('Trash');
+
+  fireEvent.click(getAllByLabelText('Delete')[0]);
+  expect(screen.getByText('Are you sure you want to delete this title?')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Yes'));
+
+  await new Promise(r => setTimeout(r, 0));
+  expect(queryByText('Trash')).toBeNull();
+});

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import ListSection from './ListSection';
 
-// Skipping these tests because the project does not include a DOM environment
-// such as jsdom. They rely on DOM APIs which are unavailable in this
-// restricted environment.
-describe.skip('ListSection', () => {
+describe('ListSection', () => {
   test('calls onAdd when Add button clicked', () => {
     const onAdd = jest.fn();
     const { getByPlaceholderText, getByText } = render(
@@ -38,5 +35,39 @@ describe.skip('ListSection', () => {
     );
     expect(queryByText('Star Wars')).toBeNull();
     expect(queryByText('Toy Story')).toBeInTheDocument();
+  });
+
+  test('calls onMove when Move button clicked', () => {
+    const onMove = jest.fn();
+    const { getAllByLabelText } = render(
+      <ListSection
+        title="Wishlist"
+        items={['A']}
+        onMove={onMove}
+        onDelete={() => {}}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter=""
+      />
+    );
+    fireEvent.click(getAllByLabelText('Move')[0]);
+    expect(onMove).toHaveBeenCalledWith(0);
+  });
+
+  test('calls onDelete when Delete button clicked', () => {
+    const onDelete = jest.fn();
+    const { getAllByLabelText } = render(
+      <ListSection
+        title="Wishlist"
+        items={['A']}
+        onMove={() => {}}
+        onDelete={onDelete}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter=""
+      />
+    );
+    fireEvent.click(getAllByLabelText('Delete')[0]);
+    expect(onDelete).toHaveBeenCalledWith(0);
   });
 });


### PR DESCRIPTION
## Summary
- re-enable ListSection tests and verify move/delete callbacks
- add new tests covering confirmation logic in App

## Testing
- `npm test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ded7a28832eb0fc22b562eb40ca