### PR TITLE
Add tests for move/delete controls

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,8 +1,38 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
 test('renders heading', () => {
   render(<App />);
   expect(screen.getByText(/DVD Collection Tracker/i)).toBeInTheDocument();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+function renderWithData(data) {
+  localStorage.setItem('dvdData', JSON.stringify(data));
+  localStorage.setItem('dvdDataTimestamp', Date.now().toString());
+  return render(<App />);
+}
+
+test('move shows confirmation and moves item on confirm', () => {
+  const { container } = renderWithData({ owned: [], wishlist: ['A'] });
+  fireEvent.click(screen.getByLabelText('Move'));
+  expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const wishlistItems = container.querySelectorAll('.wishlist-item');
+  expect(Array.from(wishlistItems).some((li) => li.textContent.includes('A'))).toBe(false);
+  const ownedItems = container.querySelectorAll('.owned-item');
+  expect(Array.from(ownedItems).some((li) => li.textContent.includes('A'))).toBe(true);
+});
+
+test('delete shows confirmation and removes item on confirm', () => {
+  const { container } = renderWithData({ owned: ['B'], wishlist: [] });
+  fireEvent.click(screen.getByLabelText('Delete'));
+  expect(screen.getByText('Are you sure you want to delete this title?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const ownedItems = container.querySelectorAll('.owned-item');
+  expect(ownedItems.length).toBe(0);
 });

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -34,6 +34,42 @@ describe('ListSection', () => {
       />
     );
     expect(queryByText('Star Wars')).toBeNull();
-    expect(queryByText('Toy Story')).toBeInTheDocument();
+    expect(
+      queryByText((content, element) => element.textContent === 'Toy Story')
+    ).toBeInTheDocument();
+  });
+
+  test('calls onMove when Move button clicked', () => {
+    const onMove = jest.fn();
+    const { getByLabelText } = render(
+      <ListSection
+        title="Wishlist"
+        items={["A"]}
+        onMove={onMove}
+        onDelete={() => {}}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter=""
+      />
+    );
+    fireEvent.click(getByLabelText('Move'));
+    expect(onMove).toHaveBeenCalledWith(0);
+  });
+
+  test('calls onDelete when Delete button clicked', () => {
+    const onDelete = jest.fn();
+    const { getByLabelText } = render(
+      <ListSection
+        title="Wishlist"
+        items={["A"]}
+        onMove={() => {}}
+        onDelete={onDelete}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter=""
+      />
+    );
+    fireEvent.click(getByLabelText('Delete'));
+    expect(onDelete).toHaveBeenCalledWith(0);
   });
 });


### PR DESCRIPTION
## Summary
- verify move and delete controls in ListSection
- cover confirmation logic in App

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d539a7390832ea397965a294f4638