### PR TITLE
Fix duplicate wishlist entries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,16 +75,12 @@ export default function App() {
 
   const moveFromWishlist = (idx) => {
     requestConfirm('Move this title to owned?', () => {
-      setWishlist((w) => {
-        const newW = [...w];
-        const [item] = newW.splice(idx, 1);
-        setOwned((o) => {
-          const newO = [...o, item];
-          saveToLocalStorage(newO, newW);
-          return newO;
-        });
-        return newW;
-      });
+      const item = wishlist[idx];
+      const newW = wishlist.filter((_, i) => i !== idx);
+      const newO = [...owned, item];
+      setWishlist(newW);
+      setOwned(newO);
+      saveToLocalStorage(newO, newW);
     });
   };
 
@@ -101,16 +97,12 @@ export default function App() {
 
   const moveFromOwned = (idx) => {
     requestConfirm('Move this title back to wishlist?', () => {
-      setOwned((o) => {
-        const newO = [...o];
-        const [item] = newO.splice(idx, 1);
-        setWishlist((w) => {
-          const newW = [...w, item];
-          saveToLocalStorage(newO, newW);
-          return newW;
-        });
-        return newO;
-      });
+      const item = owned[idx];
+      const newO = owned.filter((_, i) => i !== idx);
+      const newW = [...wishlist, item];
+      setOwned(newO);
+      setWishlist(newW);
+      saveToLocalStorage(newO, newW);
     });
   };
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -36,3 +36,14 @@ test('delete shows confirmation and removes item on confirm', () => {
   const ownedItems = container.querySelectorAll('.owned-item');
   expect(ownedItems.length).toBe(0);
 });
+
+test('moving owned item adds it once to wishlist', () => {
+  const { container } = renderWithData({ owned: ['C'], wishlist: [] });
+  const moveBtn = container.querySelector('.owned-item .move-button');
+  fireEvent.click(moveBtn);
+  expect(screen.getByText('Move this title back to wishlist?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const wishlistItems = container.querySelectorAll('.wishlist-item');
+  expect(wishlistItems.length).toBe(1);
+  expect(wishlistItems[0].textContent).toContain('C');
+});


### PR DESCRIPTION
## Summary
- avoid side effects in move handlers to prevent duplicate items
- test moving from owned to wishlist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6d70a0d0832ea11e0483e1bb9f5e