### PR TITLE
Highlight duplicate titles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import ListSection from './components/ListSection';
 import ConfirmDialog from './components/ConfirmDialog';
 import { sortTitles } from './utils';
@@ -10,6 +10,16 @@ export default function App() {
   const [lastModified, setLastModified] = useState('');
   const importRef = useRef(null);
   const [confirmState, setConfirmState] = useState(null);
+
+  const duplicates = useMemo(() => {
+    const ownedSet = new Set(owned.map((t) => t.toLowerCase()));
+    const wishSet = new Set(wishlist.map((t) => t.toLowerCase()));
+    const dup = new Set();
+    ownedSet.forEach((t) => {
+      if (wishSet.has(t)) dup.add(t);
+    });
+    return dup;
+  }, [owned, wishlist]);
 
   useEffect(() => {
     loadData();
@@ -218,6 +228,7 @@ export default function App() {
         onAdd={addWishlist}
         placeholder="Add to wishlist"
         filter={filter}
+        duplicates={duplicates}
       />
       <ListSection
         title="Owned"
@@ -227,6 +238,7 @@ export default function App() {
         onAdd={addOwned}
         placeholder="Add to owned"
         filter={filter}
+        duplicates={duplicates}
       />
       <div className="storage-buttons">
         <button onClick={exportData}>Export</button>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -86,3 +86,11 @@ test('adding to owned keeps items sorted', () => {
   const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
   expect(ownedTitles).toEqual(['A', 'B']);
 });
+
+test('items in both lists get duplicate-item class', () => {
+  const { container } = renderWithData({ owned: ['A'], wishlist: ['a'] });
+  const wishLi = container.querySelector('.wishlist-item');
+  const ownLi = container.querySelector('.owned-item');
+  expect(wishLi.classList.contains('duplicate-item')).toBe(true);
+  expect(ownLi.classList.contains('duplicate-item')).toBe(true);
+});

--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -9,6 +9,7 @@ export default function ListSection({
   onDelete = () => {},
   placeholder,
   filter,
+  duplicates = new Set(),
 }) {
   const [input, setInput] = useState('');
 
@@ -44,7 +45,9 @@ export default function ListSection({
           matches.map((o) => (
             <li
               key={o.i}
-              className={`${title.toLowerCase()}-item`}
+              className={`${title.toLowerCase()}-item${
+                duplicates.has(o.t.toLowerCase()) ? ' duplicate-item' : ''
+              }`}
             >
               <span
                 dangerouslySetInnerHTML={{

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -72,4 +72,23 @@ describe('ListSection', () => {
     fireEvent.click(getByLabelText('Delete'));
     expect(onDelete).toHaveBeenCalledWith(0);
   });
+
+  test('adds duplicate-item class when title is duplicate', () => {
+    const { getByText } = render(
+      <ListSection
+        title="Wishlist"
+        items={["A", "B"]}
+        onMove={() => {}}
+        onDelete={() => {}}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter=""
+        duplicates={new Set(["a"])}
+      />
+    );
+    const dupLi = getByText('A').closest('li');
+    const otherLi = getByText('B').closest('li');
+    expect(dupLi.classList.contains('duplicate-item')).toBe(true);
+    expect(otherLi.classList.contains('duplicate-item')).toBe(false);
+  });
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -176,6 +176,9 @@ li:hover {
   padding-left: 0.8rem;
   opacity: 0.7;
 }
+.duplicate-item {
+  outline: 2px solid var(--accent);
+}
 .match-highlight {
   background: var(--accent);
   color: var(--bg);


### PR DESCRIPTION
## Summary
- compute `duplicates` in `App` using owned/wishlist updates
- pass the set to `ListSection`
- mark list items with `duplicate-item` when present in the set
- style duplicates with a highlighted outline
- test for new duplicate logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d73968ca8832eafd41c85925a0b47