### PR TITLE
Implement duplicate title confirmation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,19 +134,45 @@ export default function App() {
   };
 
   const addWishlist = (title) => {
-    setWishlist((w) => {
-      const newW = sortTitles([...w, title]);
-      saveToLocalStorage(owned, newW);
-      return newW;
-    });
+    const normalized = title.toLowerCase();
+    const exists =
+      wishlist.some((t) => t.toLowerCase() === normalized) ||
+      owned.some((t) => t.toLowerCase() === normalized);
+
+    const insert = () => {
+      setWishlist((w) => {
+        const newW = sortTitles([...w, title]);
+        saveToLocalStorage(owned, newW);
+        return newW;
+      });
+    };
+
+    if (exists) {
+      requestConfirm('Title already exists—add anyway?', insert);
+    } else {
+      insert();
+    }
   };
 
   const addOwned = (title) => {
-    setOwned((o) => {
-      const newO = sortTitles([...o, title]);
-      saveToLocalStorage(newO, wishlist);
-      return newO;
-    });
+    const normalized = title.toLowerCase();
+    const exists =
+      owned.some((t) => t.toLowerCase() === normalized) ||
+      wishlist.some((t) => t.toLowerCase() === normalized);
+
+    const insert = () => {
+      setOwned((o) => {
+        const newO = sortTitles([...o, title]);
+        saveToLocalStorage(newO, wishlist);
+        return newO;
+      });
+    };
+
+    if (exists) {
+      requestConfirm('Title already exists—add anyway?', insert);
+    } else {
+      insert();
+    }
   };
 
   const clearSearch = () => setFilter('');

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -94,3 +94,29 @@ test('items in both lists get duplicate-item class', () => {
   expect(wishLi.classList.contains('duplicate-item')).toBe(true);
   expect(ownLi.classList.contains('duplicate-item')).toBe(true);
 });
+
+test('duplicate add shows confirmation and adds on confirm', () => {
+  const { container, getByPlaceholderText } = renderWithData({ owned: ['A'], wishlist: [] });
+  const input = getByPlaceholderText('Add to wishlist');
+  fireEvent.change(input, { target: { value: 'a' } });
+  const addBtn = input.parentElement.querySelector('button');
+  fireEvent.click(addBtn);
+  expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const wishItems = container.querySelectorAll('.wishlist-item span');
+  expect(wishItems.length).toBe(1);
+  expect(wishItems[0].textContent).toBe('a');
+});
+
+test('duplicate add does not add when cancelled', () => {
+  const { container, getByPlaceholderText } = renderWithData({ owned: ['A'], wishlist: [] });
+  const input = getByPlaceholderText('Add to wishlist');
+  fireEvent.change(input, { target: { value: 'a' } });
+  const addBtn = input.parentElement.querySelector('button');
+  fireEvent.click(addBtn);
+  expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('No'));
+  expect(screen.queryByText('Title already exists—add anyway?')).toBeNull();
+  const wishItems = container.querySelectorAll('.wishlist-item span');
+  expect(wishItems.length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- detect duplicates before adding titles to either list
- prompt the user when duplicates are found using `ConfirmDialog`
- only add the title if the user confirms
- test duplicate addition confirmation and cancellation flows

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d7565cde4832ea9e388529e605485