### PR TITLE
Improve list ordering tests

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -120,3 +120,40 @@ test('duplicate add does not add when cancelled', () => {
   const wishItems = container.querySelectorAll('.wishlist-item span');
   expect(wishItems.length).toBe(0);
 });
+
+test('duplicate add highlights items on confirm', () => {
+  const { container, getByPlaceholderText } = renderWithData({ owned: ['A'], wishlist: [] });
+  const input = getByPlaceholderText('Add to wishlist');
+  fireEvent.change(input, { target: { value: 'a' } });
+  const addBtn = input.parentElement.querySelector('button');
+  fireEvent.click(addBtn);
+  expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const wishLi = container.querySelector('.wishlist-item');
+  const ownLi = container.querySelector('.owned-item');
+  expect(wishLi.classList.contains('duplicate-item')).toBe(true);
+  expect(ownLi.classList.contains('duplicate-item')).toBe(true);
+});
+
+test('moving from wishlist keeps both lists sorted', () => {
+  const { container } = renderWithData({ owned: ['A', 'C'], wishlist: ['B', 'D'] });
+  fireEvent.click(container.querySelector('.wishlist-item .move-button'));
+  expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
+  const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
+  expect(ownedTitles).toEqual(['A', 'B', 'C']);
+  expect(wishlistTitles).toEqual(['D']);
+});
+
+test('moving from owned keeps both lists sorted', () => {
+  const { container } = renderWithData({ owned: ['A', 'C', 'E'], wishlist: ['B', 'D'] });
+  const moveBtn = container.querySelectorAll('.owned-item .move-button')[1];
+  fireEvent.click(moveBtn);
+  expect(screen.getByText('Move this title back to wishlist?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Yes'));
+  const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
+  const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
+  expect(ownedTitles).toEqual(['A', 'E']);
+  expect(wishlistTitles).toEqual(['B', 'C', 'D']);
+});

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -91,4 +91,25 @@ describe('ListSection', () => {
     expect(dupLi.classList.contains('duplicate-item')).toBe(true);
     expect(otherLi.classList.contains('duplicate-item')).toBe(false);
   });
+
+  test('multiple duplicates all receive duplicate-item class', () => {
+    const { getByText } = render(
+      <ListSection
+        title="Wishlist"
+        items={["A", "B", "C"]}
+        onMove={() => {}}
+        onDelete={() => {}}
+        onAdd={() => {}}
+        placeholder="Add item"
+        filter=""
+        duplicates={new Set(["a", "c"])}
+      />
+    );
+    const aLi = getByText('A').closest('li');
+    const bLi = getByText('B').closest('li');
+    const cLi = getByText('C').closest('li');
+    expect(aLi.classList.contains('duplicate-item')).toBe(true);
+    expect(cLi.classList.contains('duplicate-item')).toBe(true);
+    expect(bLi.classList.contains('duplicate-item')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- expand `App` tests for sorting and duplicates
- extend `ListSection` tests to cover multiple duplicates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d783f36cc832e9fecb4fec892da4d