### PR TITLE
Add modal add dialog

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -49,11 +49,10 @@ test('moving owned item adds it once to wishlist', () => {
 });
 
 test('adding to wishlist keeps items sorted', () => {
-  const { container, getByPlaceholderText } = renderWithData({ owned: [], wishlist: ['B'] });
-  const input = getByPlaceholderText('Add to wishlist');
-  fireEvent.change(input, { target: { value: 'A' } });
-  const addBtn = input.parentElement.querySelector('button');
-  fireEvent.click(addBtn);
+  const { container } = renderWithData({ owned: [], wishlist: ['B'] });
+  fireEvent.click(screen.getByLabelText('Add'));
+  fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A' } });
+  fireEvent.click(screen.getByText('Add'));
   const items = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
   expect(items).toEqual(['A', 'B']);
 });
@@ -78,11 +77,11 @@ test('moving from owned keeps wishlist sorted', () => {
 });
 
 test('adding to owned keeps items sorted', () => {
-  const { container, getByPlaceholderText } = renderWithData({ owned: ['B'], wishlist: [] });
-  const input = getByPlaceholderText('Add to owned');
-  fireEvent.change(input, { target: { value: 'A' } });
-  const addBtn = input.parentElement.querySelector('button');
-  fireEvent.click(addBtn);
+  const { container } = renderWithData({ owned: ['B'], wishlist: [] });
+  fireEvent.click(screen.getByLabelText('Add'));
+  fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A' } });
+  fireEvent.change(screen.getByLabelText('Target list'), { target: { value: 'owned' } });
+  fireEvent.click(screen.getByText('Add'));
   const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
   expect(ownedTitles).toEqual(['A', 'B']);
 });
@@ -96,11 +95,10 @@ test('items in both lists get duplicate-item class', () => {
 });
 
 test('duplicate add shows confirmation and adds on confirm', () => {
-  const { container, getByPlaceholderText } = renderWithData({ owned: ['A'], wishlist: [] });
-  const input = getByPlaceholderText('Add to wishlist');
-  fireEvent.change(input, { target: { value: 'a' } });
-  const addBtn = input.parentElement.querySelector('button');
-  fireEvent.click(addBtn);
+  const { container } = renderWithData({ owned: ['A'], wishlist: [] });
+  fireEvent.click(screen.getByLabelText('Add'));
+  fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
+  fireEvent.click(screen.getByText('Add'));
   expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const wishItems = container.querySelectorAll('.wishlist-item span');
@@ -109,11 +107,10 @@ test('duplicate add shows confirmation and adds on confirm', () => {
 });
 
 test('duplicate add does not add when cancelled', () => {
-  const { container, getByPlaceholderText } = renderWithData({ owned: ['A'], wishlist: [] });
-  const input = getByPlaceholderText('Add to wishlist');
-  fireEvent.change(input, { target: { value: 'a' } });
-  const addBtn = input.parentElement.querySelector('button');
-  fireEvent.click(addBtn);
+  const { container } = renderWithData({ owned: ['A'], wishlist: [] });
+  fireEvent.click(screen.getByLabelText('Add'));
+  fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
+  fireEvent.click(screen.getByText('Add'));
   expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('No'));
   expect(screen.queryByText('Title already exists—add anyway?')).toBeNull();
@@ -122,11 +119,10 @@ test('duplicate add does not add when cancelled', () => {
 });
 
 test('duplicate add highlights items on confirm', () => {
-  const { container, getByPlaceholderText } = renderWithData({ owned: ['A'], wishlist: [] });
-  const input = getByPlaceholderText('Add to wishlist');
-  fireEvent.change(input, { target: { value: 'a' } });
-  const addBtn = input.parentElement.querySelector('button');
-  fireEvent.click(addBtn);
+  const { container } = renderWithData({ owned: ['A'], wishlist: [] });
+  fireEvent.click(screen.getByLabelText('Add'));
+  fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
+  fireEvent.click(screen.getByText('Add'));
   expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const wishLi = container.querySelector('.wishlist-item');

--- a/src/components/AddDialog.jsx
+++ b/src/components/AddDialog.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+export default function AddDialog({ onAdd, onCancel }) {
+  const [title, setTitle] = useState('');
+  const [list, setList] = useState('wishlist');
+
+  const handleAdd = () => {
+    const val = title.trim();
+    if (!val) return;
+    onAdd(list, val);
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal add-dialog">
+        <input
+          type="text"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleAdd();
+            }
+          }}
+          autoFocus
+        />
+        <select
+          value={list}
+          onChange={(e) => setList(e.target.value)}
+          aria-label="Target list"
+        >
+          <option value="wishlist">Wishlist</option>
+          <option value="owned">Owned</option>
+        </select>
+        <div className="modal-buttons">
+          <button onClick={handleAdd}>Add</button>
+          <button onClick={onCancel}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -1,31 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { highlightMatch } from '../utils';
 
 export default function ListSection({
   title,
   items,
   onMove = () => {},
-  onAdd,
   onDelete = () => {},
-  placeholder,
   filter,
   duplicates = new Set(),
 }) {
-  const [input, setInput] = useState('');
-
-  const handleAdd = () => {
-    const val = input.trim();
-    if (!val) return;
-    onAdd(val);
-    setInput('');
-  };
-
-  const handleKeyPress = (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleAdd();
-    }
-  };
 
   const normFilter = filter.toLowerCase();
   const matches = items
@@ -78,16 +61,6 @@ export default function ListSection({
           ))
         )}
       </ul>
-      <div className="add-form">
-        <input
-          type="text"
-          placeholder={placeholder}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyPress={handleKeyPress}
-        />
-        <button onClick={handleAdd}>Add</button>
-      </div>
     </div>
   );
 }

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -3,23 +3,6 @@ import { render, fireEvent } from '@testing-library/react';
 import ListSection from './ListSection';
 
 describe('ListSection', () => {
-  test('calls onAdd when Add button clicked', () => {
-    const onAdd = jest.fn();
-    const { getByPlaceholderText, getByText } = render(
-      <ListSection
-        title="Wishlist"
-        items={[]}
-        onMove={() => {}}
-        onDelete={() => {}}
-        onAdd={onAdd}
-        placeholder="Add item"
-        filter=""
-      />
-    );
-    fireEvent.change(getByPlaceholderText('Add item'), { target: { value: 'DVD' } });
-    fireEvent.click(getByText('Add'));
-    expect(onAdd).toHaveBeenCalledWith('DVD');
-  });
 
   test('filters items based on filter prop', () => {
     const { queryByText } = render(
@@ -28,8 +11,6 @@ describe('ListSection', () => {
         items={['Star Wars', 'Toy Story']}
         onMove={() => {}}
         onDelete={() => {}}
-        onAdd={() => {}}
-        placeholder="Add item"
         filter="toy"
       />
     );
@@ -47,8 +28,6 @@ describe('ListSection', () => {
         items={["A"]}
         onMove={onMove}
         onDelete={() => {}}
-        onAdd={() => {}}
-        placeholder="Add item"
         filter=""
       />
     );
@@ -64,8 +43,6 @@ describe('ListSection', () => {
         items={["A"]}
         onMove={() => {}}
         onDelete={onDelete}
-        onAdd={() => {}}
-        placeholder="Add item"
         filter=""
       />
     );
@@ -80,8 +57,6 @@ describe('ListSection', () => {
         items={["A", "B"]}
         onMove={() => {}}
         onDelete={() => {}}
-        onAdd={() => {}}
-        placeholder="Add item"
         filter=""
         duplicates={new Set(["a"])}
       />
@@ -99,8 +74,6 @@ describe('ListSection', () => {
         items={["A", "B", "C"]}
         onMove={() => {}}
         onDelete={() => {}}
-        onAdd={() => {}}
-        placeholder="Add item"
         filter=""
         duplicates={new Set(["a", "c"])}
       />

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,6 +23,25 @@ h1 {
   letter-spacing: 0.05em;
   text-align: center;
 }
+header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.add-button {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: 0.3rem;
+  padding: 0 0.6rem;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.add-button:hover {
+  background: #0298c4;
+}
 .search-container {
   width: 100%;
   max-width: 30rem;
@@ -57,31 +76,6 @@ h1 {
 }
 .clear-search-button.visible {
   display: inline-block;
-}
-.add-form {
-  margin-top: 0.5rem;
-  display: flex;
-  gap: 0.5rem;
-}
-.add-form input {
-  flex: 1;
-  padding: 0.4rem 0.6rem;
-  border: none;
-  border-radius: 0.3rem;
-  background: #1e1e1e;
-  color: var(--fg);
-}
-.add-form button {
-  background: var(--accent);
-  color: var(--bg);
-  border: none;
-  border-radius: 0.3rem;
-  padding: 0.4rem 0.8rem;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-.add-form button:hover {
-  background: #0298c4;
 }
 
 .storage-buttons {
@@ -249,6 +243,16 @@ footer p {
   border-radius: 0.3rem;
   max-width: 20rem;
   text-align: center;
+}
+.add-dialog input,
+.add-dialog select {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border: none;
+  border-radius: 0.3rem;
+  background: #1e1e1e;
+  color: var(--fg);
 }
 
 .modal-buttons {


### PR DESCRIPTION
## Summary
- add global Add button in `<header>`
- create `<AddDialog>` modal for selecting list and entering title
- manage new dialog state in `App.jsx`
- consolidate add handlers into `addItem`
- strip list-section add form and its CSS
- adapt unit tests for modal add dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7e09a2e0832e9bb9e12a5cd4754e