### PR TITLE
Add item menu for list actions

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -19,7 +19,8 @@ function renderWithData(data) {
 
 test('move shows confirmation and moves item on confirm', () => {
   const { container } = renderWithData({ owned: [], wishlist: ['A'] });
-  fireEvent.click(screen.getByLabelText('Move'));
+  fireEvent.click(screen.getByLabelText('Actions'));
+  fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const wishlistItems = container.querySelectorAll('.wishlist-item');
@@ -30,7 +31,8 @@ test('move shows confirmation and moves item on confirm', () => {
 
 test('delete shows confirmation and removes item on confirm', () => {
   const { container } = renderWithData({ owned: ['B'], wishlist: [] });
-  fireEvent.click(screen.getByLabelText('Delete'));
+  fireEvent.click(screen.getByLabelText('Actions'));
+  fireEvent.click(screen.getByText('Delete'));
   expect(screen.getByText('Are you sure you want to delete this title?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const ownedItems = container.querySelectorAll('.owned-item');
@@ -39,8 +41,9 @@ test('delete shows confirmation and removes item on confirm', () => {
 
 test('moving owned item adds it once to wishlist', () => {
   const { container } = renderWithData({ owned: ['C'], wishlist: [] });
-  const moveBtn = container.querySelector('.owned-item .move-button');
+  const moveBtn = container.querySelector('.owned-item .item-menu-button');
   fireEvent.click(moveBtn);
+  fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title back to wishlist?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const wishlistItems = container.querySelectorAll('.wishlist-item');
@@ -59,7 +62,9 @@ test('adding to wishlist keeps items sorted', () => {
 
 test('moving from wishlist sorts owned list', () => {
   const { container } = renderWithData({ owned: ['C'], wishlist: ['A'] });
-  fireEvent.click(container.querySelector('.wishlist-item .move-button'));
+  const menuBtn = container.querySelector('.wishlist-item .item-menu-button');
+  fireEvent.click(menuBtn);
+  fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
@@ -68,8 +73,9 @@ test('moving from wishlist sorts owned list', () => {
 
 test('moving from owned keeps wishlist sorted', () => {
   const { container } = renderWithData({ owned: ['B'], wishlist: ['A'] });
-  const moveBtn = container.querySelector('.owned-item .move-button');
+  const moveBtn = container.querySelector('.owned-item .item-menu-button');
   fireEvent.click(moveBtn);
+  fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title back to wishlist?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const wishTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
@@ -133,7 +139,9 @@ test('duplicate add highlights items on confirm', () => {
 
 test('moving from wishlist keeps both lists sorted', () => {
   const { container } = renderWithData({ owned: ['A', 'C'], wishlist: ['B', 'D'] });
-  fireEvent.click(container.querySelector('.wishlist-item .move-button'));
+  const menuBtn = container.querySelector('.wishlist-item .item-menu-button');
+  fireEvent.click(menuBtn);
+  fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
@@ -144,8 +152,9 @@ test('moving from wishlist keeps both lists sorted', () => {
 
 test('moving from owned keeps both lists sorted', () => {
   const { container } = renderWithData({ owned: ['A', 'C', 'E'], wishlist: ['B', 'D'] });
-  const moveBtn = container.querySelectorAll('.owned-item .move-button')[1];
+  const moveBtn = container.querySelectorAll('.owned-item .item-menu-button')[1];
   fireEvent.click(moveBtn);
+  fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title back to wishlist?')).toBeInTheDocument();
   fireEvent.click(screen.getByText('Yes'));
   const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);

--- a/src/components/ItemMenu.jsx
+++ b/src/components/ItemMenu.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function ItemMenu({ onMove, onDelete }) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef(null);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClick = (e) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        buttonRef.current && buttonRef.current.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    const firstBtn = menuRef.current.querySelector('button');
+    firstBtn && firstBtn.focus();
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const handleKeyNav = (e) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    const buttons = Array.from(menuRef.current.querySelectorAll('button'));
+    const idx = buttons.indexOf(document.activeElement);
+    const next = e.key === 'ArrowDown' ? idx + 1 : idx - 1;
+    const wrap = (n) => (n + buttons.length) % buttons.length;
+    buttons[wrap(next)].focus();
+  };
+
+  return (
+    <div className="item-menu-wrapper">
+      <button
+        className="item-menu-button"
+        aria-label="Actions"
+        aria-haspopup="true"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        ref={buttonRef}
+      >
+        \u22ee
+      </button>
+      {open && (
+        <div className="item-menu" ref={menuRef} onKeyDown={handleKeyNav}>
+          <button
+            onClick={() => {
+              onMove();
+              setOpen(false);
+            }}
+          >
+            Move
+          </button>
+          <button
+            onClick={() => {
+              onDelete();
+              setOpen(false);
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { highlightMatch } from '../utils';
+import ItemMenu from './ItemMenu';
 
 export default function ListSection({
   title,
@@ -37,26 +38,10 @@ export default function ListSection({
                   __html: highlightMatch(o.t, normFilter),
                 }}
               />
-              <button
-                className="move-button"
-                aria-label="Move"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onMove(o.i);
-                }}
-              >
-                ➡️
-              </button>
-              <button
-                className="delete-button"
-                aria-label="Delete"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete(o.i);
-                }}
-              >
-                🗑️
-              </button>
+              <ItemMenu
+                onMove={() => onMove(o.i)}
+                onDelete={() => onDelete(o.i)}
+              />
             </li>
           ))
         )}

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -20,9 +20,9 @@ describe('ListSection', () => {
     ).toBeInTheDocument();
   });
 
-  test('calls onMove when Move button clicked', () => {
+  test('calls onMove when Move option clicked', () => {
     const onMove = jest.fn();
-    const { getByLabelText } = render(
+    const { getByLabelText, getByText } = render(
       <ListSection
         title="Wishlist"
         items={["A"]}
@@ -31,13 +31,14 @@ describe('ListSection', () => {
         filter=""
       />
     );
-    fireEvent.click(getByLabelText('Move'));
+    fireEvent.click(getByLabelText('Actions'));
+    fireEvent.click(getByText('Move'));
     expect(onMove).toHaveBeenCalledWith(0);
   });
 
-  test('calls onDelete when Delete button clicked', () => {
+  test('calls onDelete when Delete option clicked', () => {
     const onDelete = jest.fn();
-    const { getByLabelText } = render(
+    const { getByLabelText, getByText } = render(
       <ListSection
         title="Wishlist"
         items={["A"]}
@@ -46,7 +47,8 @@ describe('ListSection', () => {
         filter=""
       />
     );
-    fireEvent.click(getByLabelText('Delete'));
+    fireEvent.click(getByLabelText('Actions'));
+    fireEvent.click(getByText('Delete'));
     expect(onDelete).toHaveBeenCalledWith(0);
   });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -161,6 +161,45 @@ li:hover {
 .move-button:hover {
   color: #fff;
 }
+.item-menu-wrapper {
+  position: absolute;
+  right: 0.2rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.item-menu-button {
+  background: transparent;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  padding: 0 0.3rem;
+}
+.item-menu-button:hover {
+  color: #fff;
+}
+.item-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 0.2rem;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 0.3rem;
+  display: flex;
+  flex-direction: column;
+  z-index: 5;
+}
+.item-menu button {
+  background: none;
+  border: none;
+  color: var(--fg);
+  padding: 0.3rem 0.6rem;
+  text-align: left;
+  cursor: pointer;
+}
+.item-menu button:hover,
+.item-menu button:focus {
+  background: #333;
+}
 .wishlist-item {
   border-left: 3px solid var(--wishlist);
   padding-left: 0.8rem;
@@ -222,6 +261,9 @@ footer p {
   li { padding: 0.5rem 0.3rem; font-size: 0.9rem; }
   .move-button,
   .delete-button {
+    font-size: 1rem;
+  }
+  .item-menu-button {
     font-size: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- remove inline Move/Delete buttons and use a new kebab menu
- implement `ItemMenu` component with keyboard nav and outside-click close
- position menu with new styles
- update tests for the menu-driven actions

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_686d9c2e9968832e8140bcdeccebb77b