### PR TITLE
Remove obsolete help paragraph

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -218,11 +218,6 @@ export default function App() {
           +
         </button>
       </header>
-      <p className="search-info">
-        Use the Move button to send a title to the other list or Delete to
-        remove it. A confirmation dialog will appear before either action is
-        applied.
-      </p>
       <div className="search-container">
         <input
           id="searchBox"


### PR DESCRIPTION
## Summary
- delete the help paragraph from `App.jsx`
- confirm no references to the removed text remain in docs or tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d9f6c0e28832eb859b2d0ba55dcb9