### PR TITLE
Fix ItemMenu ellipsis and menu styling

### DIFF
--- a/src/components/ItemMenu.jsx
+++ b/src/components/ItemMenu.jsx
@@ -56,7 +56,7 @@ export default function ItemMenu({ onMove, onDelete }) {
         onClick={() => setOpen((o) => !o)}
         ref={buttonRef}
       >
-        \u22ee
+        {'\u22ee'}
       </button>
       {open && (
         <div className="item-menu" ref={menuRef} onKeyDown={handleKeyNav}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -182,11 +182,13 @@ li:hover {
   right: 0;
   margin-top: 0.2rem;
   background: #1e1e1e;
+  background-color: #1e1e1e;
   border: 1px solid #333;
   border-radius: 0.3rem;
   display: flex;
   flex-direction: column;
-  z-index: 5;
+  min-width: max-content;
+  z-index: 100;
 }
 .item-menu button {
   background: none;
@@ -195,6 +197,7 @@ li:hover {
   padding: 0.3rem 0.6rem;
   text-align: left;
   cursor: pointer;
+  white-space: nowrap;
 }
 .item-menu button:hover,
 .item-menu button:focus {


### PR DESCRIPTION
## Summary
- display ItemMenu ellipsis using JS escape
- ensure menu stays on top and text doesn't wrap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686da4ea2760832e94f5e8124cfc81c8