### PR TITLE
Display Access user

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,13 +2,14 @@ import React, { useEffect, useRef, useState, useMemo } from 'react';
 import ListSection from './components/ListSection';
 import ConfirmDialog from './components/ConfirmDialog';
 import AddDialog from './components/AddDialog';
-import { sortTitles, addItem as computeAddItem } from './utils';
+import { sortTitles, addItem as computeAddItem, getAccessUser } from './utils';
 
 export default function App() {
   const [owned, setOwned] = useState([]);
   const [wishlist, setWishlist] = useState([]);
   const [filter, setFilter] = useState('');
   const [lastModified, setLastModified] = useState('');
+  const [user, setUser] = useState(null);
   const importRef = useRef(null);
   const [confirmState, setConfirmState] = useState(null);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -25,6 +26,7 @@ export default function App() {
 
   useEffect(() => {
     loadData();
+    setUser(getAccessUser());
   }, []);
 
   function loadFromLocalStorage() {
@@ -261,6 +263,7 @@ export default function App() {
       </div>
       <footer>
         <p>Last modified: {lastModified || 'Loading...'}</p>
+        {user && <p>Logged in as: {user}</p>}
       </footer>
       {addDialogOpen && (
         <AddDialog

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -14,6 +14,8 @@ test('search input has aria-label', () => {
 
 afterEach(() => {
   localStorage.clear();
+  document.cookie =
+    'CF_Authorization=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
 });
 
 function renderWithData(data) {
@@ -166,4 +168,11 @@ test('moving from owned keeps both lists sorted', () => {
   const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
   expect(ownedTitles).toEqual(['A', 'E']);
   expect(wishlistTitles).toEqual(['B', 'C', 'D']);
+});
+
+test('shows user from Access cookie', () => {
+  const payload = btoa(JSON.stringify({ email: 'test@example.com' }));
+  document.cookie = `CF_Authorization=header.${payload}.sig`;
+  render(<App />);
+  expect(screen.getByText(/Logged in as:/)).toHaveTextContent('test@example.com');
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,3 +28,22 @@ export function addItem(list, title, owned, wishlist) {
     duplicate,
   };
 }
+
+export function getAccessUser() {
+  const cookie = document.cookie
+    .split('; ')
+    .find((c) => c.startsWith('CF_Authorization='));
+  if (!cookie) return null;
+  const token = cookie.split('=')[1];
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(base64);
+    const payload = JSON.parse(json);
+    return payload.email || payload.sub || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- parse CF_Authorization cookie
- show logged in user in the footer
- test that logged in user is displayed

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68716364fb1c832e825e1ec643e5632d