### PR TITLE
Highlight escaping

### DIFF
--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -33,11 +33,7 @@ export default function ListSection({
                 duplicates.has(o.t.title.toLowerCase()) ? ' duplicate-item' : ''
               }`}
             >
-              <span
-                dangerouslySetInnerHTML={{
-                  __html: highlightMatch(o.t.title, normFilter),
-                }}
-              />
+              <span>{highlightMatch(o.t.title, normFilter)}</span>
               <ItemMenu
                 onMove={() => onMove(o.i)}
                 onDelete={() => onDelete(o.i)}

--- a/src/components/ListSection.test.jsx
+++ b/src/components/ListSection.test.jsx
@@ -97,4 +97,22 @@ describe('ListSection', () => {
     expect(cLi.classList.contains('duplicate-item')).toBe(true);
     expect(bLi.classList.contains('duplicate-item')).toBe(false);
   });
+
+  test('titles containing HTML are rendered safely', () => {
+    const { container } = render(
+      <ListSection
+        title="Wishlist"
+        items={[{ id: '1', title: '<b>Danger</b>' }]}
+        onMove={() => {}}
+        onDelete={() => {}}
+        filter="danger"
+      />
+    );
+    const textSpan = container.querySelector('li span');
+    expect(textSpan.textContent).toBe('<b>Danger</b>');
+    expect(textSpan.querySelector('b')).toBeNull();
+    const highlight = textSpan.querySelector('.match-highlight');
+    expect(highlight).toBeInTheDocument();
+    expect(highlight.textContent).toBe('Danger');
+  });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,13 +2,18 @@ import React from 'react';
 
 export function highlightMatch(text, filter) {
   if (!filter) return [text];
-  const regex = new RegExp(`(${filter.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`, 'gi');
+  const regex = new RegExp(
+    `(${filter.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")})`,
+    "gi"
+  );
   return text.split(regex).map((part, idx) =>
-    idx % 2 === 1 ? (
-      <span key={idx} className="match-highlight">{part}</span>
-    ) : (
-      part
-    )
+    idx % 2 === 1
+      ? React.createElement(
+          "span",
+          { key: idx, className: "match-highlight" },
+          part
+        )
+      : part
   );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,15 @@
+import React from 'react';
+
 export function highlightMatch(text, filter) {
-  if (!filter) return text;
+  if (!filter) return [text];
   const regex = new RegExp(`(${filter.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`, 'gi');
-  return text.replace(regex, '<span class="match-highlight">$1</span>');
+  return text.split(regex).map((part, idx) =>
+    idx % 2 === 1 ? (
+      <span key={idx} className="match-highlight">{part}</span>
+    ) : (
+      part
+    )
+  );
 }
 
 export function sortTitles(list) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,11 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
 import { highlightMatch, addItem } from './utils';
 
 test('highlightMatch returns text when filter is empty', () => {
-  expect(highlightMatch('Hello', '')).toBe('Hello');
+  const { container } = render(<div>{highlightMatch('Hello', '')}</div>);
+  expect(container.textContent).toBe('Hello');
 });
 
 test('highlightMatch wraps matches', () => {
-  expect(highlightMatch('Hello', 'he')).toBe('<span class="match-highlight">He</span>llo');
+  const { container } = render(<div>{highlightMatch('Hello', 'he')}</div>);
+  const span = container.querySelector('.match-highlight');
+  expect(span).toBeInTheDocument();
+  expect(span.textContent).toBe('He');
 });
 
 test('addItem sorts and reports duplicates', () => {


### PR DESCRIPTION
## Summary
- return React nodes from `highlightMatch`
- use safer highlight output in `ListSection`
- update unit tests and add HTML safety coverage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68719a068670832e92301c13205cd965