### PR TITLE
Add D1 binding in Wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,5 +3,12 @@
     "compatibility_date": "2025-07-10",
     "assets": {
         "directory": "./docs"
-    }
+    },
+    "d1_databases": [
+        {
+            "binding": "DB",
+            "database_id": "b3f5df05-8423-4828-b452-f3de640b7db5",
+            "database_name": "dvd-db"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- configure a D1 database binding named `DB` for the Cloudflare Worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68755a6c6740832e80841cc8d0990bed