### PR TITLE
Switch storage to server API

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import 'whatwg-fetch';

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.4",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8628,6 +8629,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.4",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,48 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import App from './App';
+
+beforeEach(() => {
+  global.fetch = jest.fn((url, opts = {}) => {
+    const data = JSON.parse(localStorage.getItem('dvdData') || '{"owned":[],"wishlist":[]}');
+    if (url === '/api/collection') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(data),
+      });
+    }
+    if (url === '/api/add') {
+      const { title, list } = JSON.parse(opts.body);
+      const id = crypto.randomUUID();
+      data[list].push({ id, title });
+      localStorage.setItem('dvdData', JSON.stringify(data));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id, title }) });
+    }
+    if (url === '/api/move') {
+      const { id, to } = JSON.parse(opts.body);
+      let from = data.owned.find((i) => i.id === id) ? 'owned' : 'wishlist';
+      const item = from === 'owned'
+        ? data.owned.find((i) => i.id === id)
+        : data.wishlist.find((i) => i.id === id);
+      if (from === 'owned') {
+        data.owned = data.owned.filter((i) => i.id !== id);
+      } else {
+        data.wishlist = data.wishlist.filter((i) => i.id !== id);
+      }
+      data[to].push(item);
+      localStorage.setItem('dvdData', JSON.stringify(data));
+      return Promise.resolve({ ok: true });
+    }
+    if (url.startsWith('/api/item/')) {
+      const id = url.split('/').pop();
+      data.owned = data.owned.filter((i) => i.id !== id);
+      data.wishlist = data.wishlist.filter((i) => i.id !== id);
+      localStorage.setItem('dvdData', JSON.stringify(data));
+      return Promise.resolve({ ok: true });
+    }
+    return Promise.resolve({ ok: false });
+  });
+});
 
 test('renders heading', () => {
   render(<App />);
@@ -16,15 +58,22 @@ afterEach(() => {
   localStorage.clear();
   document.cookie =
     'CF_Authorization=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+  if (global.fetch && global.fetch.mockReset) {
+    global.fetch.mockReset();
+  }
 });
 
-function renderWithData(data) {
+async function renderWithData(data) {
   localStorage.setItem('dvdData', JSON.stringify(data));
-  return render(<App />);
+  let result;
+  await act(async () => {
+    result = render(<App />);
+  });
+  return result;
 }
 
-test('move shows confirmation and moves item on confirm', () => {
-  const { container } = renderWithData({ owned: [], wishlist: [{ id: '1', title: 'A' }] });
+test('move shows confirmation and moves item on confirm', async () => {
+  const { container } = await renderWithData({ owned: [], wishlist: [{ id: '1', title: 'A' }] });
   fireEvent.click(screen.getByLabelText('Actions'));
   fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
@@ -35,8 +84,8 @@ test('move shows confirmation and moves item on confirm', () => {
   expect(Array.from(ownedItems).some((li) => li.textContent.includes('A'))).toBe(true);
 });
 
-test('delete shows confirmation and removes item on confirm', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
+test('delete shows confirmation and removes item on confirm', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Actions'));
   fireEvent.click(screen.getByText('Delete'));
   expect(screen.getByText('Are you sure you want to delete this title?')).toBeInTheDocument();
@@ -45,8 +94,8 @@ test('delete shows confirmation and removes item on confirm', () => {
   expect(ownedItems.length).toBe(0);
 });
 
-test('moving owned item adds it once to wishlist', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'C' }], wishlist: [] });
+test('moving owned item adds it once to wishlist', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'C' }], wishlist: [] });
   const moveBtn = container.querySelector('.owned-item .item-menu-button');
   fireEvent.click(moveBtn);
   fireEvent.click(screen.getByText('Move'));
@@ -57,8 +106,8 @@ test('moving owned item adds it once to wishlist', () => {
   expect(wishlistItems[0].textContent).toContain('C');
 });
 
-test('adding to wishlist keeps items sorted', () => {
-  const { container } = renderWithData({ owned: [], wishlist: [{ id: '1', title: 'B' }] });
+test('adding to wishlist keeps items sorted', async () => {
+  const { container } = await renderWithData({ owned: [], wishlist: [{ id: '1', title: 'B' }] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A' } });
   fireEvent.click(screen.getByText('Add'));
@@ -66,8 +115,8 @@ test('adding to wishlist keeps items sorted', () => {
   expect(items).toEqual(['A', 'B']);
 });
 
-test('moving from wishlist sorts owned list', () => {
-  const { container } = renderWithData({ owned: [{ id: '2', title: 'C' }], wishlist: [{ id: '1', title: 'A' }] });
+test('moving from wishlist sorts owned list', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '2', title: 'C' }], wishlist: [{ id: '1', title: 'A' }] });
   const menuBtn = container.querySelector('.wishlist-item .item-menu-button');
   fireEvent.click(menuBtn);
   fireEvent.click(screen.getByText('Move'));
@@ -77,8 +126,8 @@ test('moving from wishlist sorts owned list', () => {
   expect(ownedTitles).toEqual(['A', 'C']);
 });
 
-test('moving from owned keeps wishlist sorted', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [{ id: '2', title: 'A' }] });
+test('moving from owned keeps wishlist sorted', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [{ id: '2', title: 'A' }] });
   const moveBtn = container.querySelector('.owned-item .item-menu-button');
   fireEvent.click(moveBtn);
   fireEvent.click(screen.getByText('Move'));
@@ -88,8 +137,8 @@ test('moving from owned keeps wishlist sorted', () => {
   expect(wishTitles).toEqual(['A', 'B']);
 });
 
-test('adding to owned keeps items sorted', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
+test('adding to owned keeps items sorted', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A' } });
   fireEvent.change(screen.getByLabelText('Target list'), { target: { value: 'owned' } });
@@ -98,16 +147,16 @@ test('adding to owned keeps items sorted', () => {
   expect(ownedTitles).toEqual(['A', 'B']);
 });
 
-test('items in both lists get duplicate-item class', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [{ id: '2', title: 'a' }] });
+test('items in both lists get duplicate-item class', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [{ id: '2', title: 'a' }] });
   const wishLi = container.querySelector('.wishlist-item');
   const ownLi = container.querySelector('.owned-item');
   expect(wishLi.classList.contains('duplicate-item')).toBe(true);
   expect(ownLi.classList.contains('duplicate-item')).toBe(true);
 });
 
-test('duplicate add shows confirmation and adds on confirm', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
+test('duplicate add shows confirmation and adds on confirm', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
   fireEvent.click(screen.getByText('Add'));
@@ -118,8 +167,8 @@ test('duplicate add shows confirmation and adds on confirm', () => {
   expect(wishItems[0].textContent).toBe('a');
 });
 
-test('duplicate add does not add when cancelled', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
+test('duplicate add does not add when cancelled', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
   fireEvent.click(screen.getByText('Add'));
@@ -130,8 +179,8 @@ test('duplicate add does not add when cancelled', () => {
   expect(wishItems.length).toBe(0);
 });
 
-test('duplicate add highlights items on confirm', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
+test('duplicate add highlights items on confirm', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
   fireEvent.click(screen.getByText('Add'));
@@ -143,8 +192,8 @@ test('duplicate add highlights items on confirm', () => {
   expect(ownLi.classList.contains('duplicate-item')).toBe(true);
 });
 
-test('moving from wishlist keeps both lists sorted', () => {
-  const { container } = renderWithData({
+test('moving from wishlist keeps both lists sorted', async () => {
+  const { container } = await renderWithData({
     owned: [
       { id: '1', title: 'A' },
       { id: '3', title: 'C' }
@@ -165,8 +214,8 @@ test('moving from wishlist keeps both lists sorted', () => {
   expect(wishlistTitles).toEqual(['D']);
 });
 
-test('moving from owned keeps both lists sorted', () => {
-  const { container } = renderWithData({
+test('moving from owned keeps both lists sorted', async () => {
+  const { container } = await renderWithData({
     owned: [
       { id: '1', title: 'A' },
       { id: '3', title: 'C' },


### PR DESCRIPTION
## Summary
- use worker API from storage helpers
- handle async storage updates in App
- add fetch polyfill and mock API for tests

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68759148ef08832eb1788fc966526393