### PR TITLE
Switch storage to Cloudflare API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import AddDialog from './components/AddDialog';
 import { sortTitles, getAccessUser } from './utils';
 import {
   loadCollection,
-  saveCollection,
   addItem as storageAddItem,
   moveItem as storageMoveItem,
   deleteItem as storageDeleteItem,
@@ -36,8 +35,8 @@ export default function App() {
   }, []);
 
 
-  function loadData() {
-    const { owned: o, wishlist: w } = loadCollection();
+  async function loadData() {
+    const { owned: o, wishlist: w } = await loadCollection();
     setOwned(o);
     setWishlist(w);
   }
@@ -45,8 +44,8 @@ export default function App() {
   const requestConfirm = (message, action) => {
     setConfirmState({
       message,
-      onConfirm: () => {
-        action();
+      onConfirm: async () => {
+        await action();
         setConfirmState(null);
       },
     });
@@ -55,8 +54,8 @@ export default function App() {
   const cancelConfirm = () => setConfirmState(null);
 
   const moveFromWishlist = (idx) => {
-    requestConfirm('Move this title to owned?', () => {
-      const { owned: newO, wishlist: newW } = storageMoveItem(
+    requestConfirm('Move this title to owned?', async () => {
+      const { owned: newO, wishlist: newW } = await storageMoveItem(
         'wishlist',
         idx,
         owned,
@@ -68,8 +67,8 @@ export default function App() {
   };
 
   const deleteFromWishlist = (idx) => {
-    requestConfirm('Are you sure you want to delete this title?', () => {
-      const { owned: newO, wishlist: newW } = storageDeleteItem(
+    requestConfirm('Are you sure you want to delete this title?', async () => {
+      const { owned: newO, wishlist: newW } = await storageDeleteItem(
         'wishlist',
         idx,
         owned,
@@ -81,8 +80,8 @@ export default function App() {
   };
 
   const moveFromOwned = (idx) => {
-    requestConfirm('Move this title back to wishlist?', () => {
-      const { owned: newO, wishlist: newW } = storageMoveItem(
+    requestConfirm('Move this title back to wishlist?', async () => {
+      const { owned: newO, wishlist: newW } = await storageMoveItem(
         'owned',
         idx,
         owned,
@@ -94,8 +93,8 @@ export default function App() {
   };
 
   const deleteFromOwned = (idx) => {
-    requestConfirm('Are you sure you want to delete this title?', () => {
-      const { owned: newO, wishlist: newW } = storageDeleteItem(
+    requestConfirm('Are you sure you want to delete this title?', async () => {
+      const { owned: newO, wishlist: newW } = await storageDeleteItem(
         'owned',
         idx,
         owned,
@@ -106,8 +105,8 @@ export default function App() {
     });
   };
 
-  const addItem = (list, title) => {
-    const result = storageAddItem(list, title, owned, wishlist);
+  const addItem = async (list, title) => {
+    const result = await storageAddItem(list, title, owned, wishlist);
     const insert = () => {
       setOwned(result.owned);
       setWishlist(result.wishlist);
@@ -153,7 +152,6 @@ export default function App() {
         const sortedW = sortTitles(normalize(parsed.wishlist));
         setOwned(sortedO);
         setWishlist(sortedW);
-        saveCollection(sortedO, sortedW);
       } catch (err) {
         alert('Invalid JSON file');
         console.error('Import failed', err);
@@ -234,8 +232,8 @@ export default function App() {
       </footer>
       {addDialogOpen && (
         <AddDialog
-          onAdd={(list, title) => {
-            addItem(list, title);
+          onAdd={async (list, title) => {
+            await addItem(list, title);
             setAddDialogOpen(false);
           }}
           onCancel={() => setAddDialogOpen(false)}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,55 +2,90 @@ import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import App from './App';
 
-test('renders heading', () => {
-  render(<App />);
-  expect(screen.getByText(/DVD Collection Tracker/i)).toBeInTheDocument();
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ owned: [], wishlist: [] })
+    })
+  );
 });
 
-test('search input has aria-label', () => {
+test('renders heading', async () => {
   render(<App />);
-  expect(screen.getByLabelText('Search titles')).toBeInTheDocument();
+  expect(await screen.findByText(/DVD Collection Tracker/i)).toBeInTheDocument();
+});
+
+test('search input has aria-label', async () => {
+  render(<App />);
+  expect(await screen.findByLabelText('Search titles')).toBeInTheDocument();
 });
 
 afterEach(() => {
-  localStorage.clear();
+  if (global.fetch) {
+    global.fetch.mockReset();
+    delete global.fetch;
+  }
   document.cookie =
     'CF_Authorization=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
 });
 
-function renderWithData(data) {
-  localStorage.setItem('dvdData', JSON.stringify(data));
-  return render(<App />);
+async function renderWithData(data) {
+  global.fetch = jest.fn((url, options) => {
+    if (url === '/api/collection') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+    }
+    if (url === '/api/add') {
+      const body = JSON.parse(options.body);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ id: 'new-id', title: body.title }),
+      });
+    }
+    if (url === '/api/move' || url.startsWith('/api/item/')) {
+      return Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve({}) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+  const utils = render(<App />);
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return utils;
 }
 
 test('move shows confirmation and moves item on confirm', async () => {
-  const { container } = renderWithData({ owned: [], wishlist: [{ id: '1', title: 'A' }] });
+  const { container } = await renderWithData({ owned: [], wishlist: [{ id: '1', title: 'A' }] });
   fireEvent.click(screen.getByLabelText('Actions'));
   fireEvent.click(screen.getByText('Move'));
   expect(screen.getByText('Move this title to owned?')).toBeInTheDocument();
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const wishlistItems = container.querySelectorAll('.wishlist-item');
-  expect(Array.from(wishlistItems).some((li) => li.textContent.includes('A'))).toBe(false);
+  await waitFor(() => {
+    const wishlistItems = container.querySelectorAll('.wishlist-item');
+    expect(Array.from(wishlistItems).some((li) => li.textContent.includes('A'))).toBe(false);
+  });
   const ownedItems = container.querySelectorAll('.owned-item');
   expect(Array.from(ownedItems).some((li) => li.textContent.includes('A'))).toBe(true);
 });
 
 test('delete shows confirmation and removes item on confirm', async () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Actions'));
   fireEvent.click(screen.getByText('Delete'));
   expect(screen.getByText('Are you sure you want to delete this title?')).toBeInTheDocument();
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const ownedItems = container.querySelectorAll('.owned-item');
-  expect(ownedItems.length).toBe(0);
+  await waitFor(() => {
+    const ownedItems = container.querySelectorAll('.owned-item');
+    expect(ownedItems.length).toBe(0);
+  });
 });
 
 test('moving owned item adds it once to wishlist', async () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'C' }], wishlist: [] });
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'C' }], wishlist: [] });
   const moveBtn = container.querySelector('.owned-item .item-menu-button');
   fireEvent.click(moveBtn);
   fireEvent.click(screen.getByText('Move'));
@@ -58,22 +93,25 @@ test('moving owned item adds it once to wishlist', async () => {
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
+  await waitFor(() => {
+    const wishlistItems = container.querySelectorAll('.wishlist-item');
+    expect(wishlistItems.length).toBe(1);
+  });
   const wishlistItems = container.querySelectorAll('.wishlist-item');
-  expect(wishlistItems.length).toBe(1);
   expect(wishlistItems[0].textContent).toContain('C');
 });
 
-test('adding to wishlist keeps items sorted', () => {
-  const { container } = renderWithData({ owned: [], wishlist: [{ id: '1', title: 'B' }] });
+test('adding to wishlist keeps items sorted', async () => {
+  const { container } = await renderWithData({ owned: [], wishlist: [{ id: '1', title: 'B' }] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A' } });
-  fireEvent.click(screen.getByText('Add'));
+  await act(async () => { fireEvent.click(screen.getByText('Add')); });
   const items = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
   expect(items).toEqual(['A', 'B']);
 });
 
 test('moving from wishlist sorts owned list', async () => {
-  const { container } = renderWithData({ owned: [{ id: '2', title: 'C' }], wishlist: [{ id: '1', title: 'A' }] });
+  const { container } = await renderWithData({ owned: [{ id: '2', title: 'C' }], wishlist: [{ id: '1', title: 'A' }] });
   const menuBtn = container.querySelector('.wishlist-item .item-menu-button');
   fireEvent.click(menuBtn);
   fireEvent.click(screen.getByText('Move'));
@@ -81,12 +119,14 @@ test('moving from wishlist sorts owned list', async () => {
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
-  expect(ownedTitles).toEqual(['A', 'C']);
+  await waitFor(() => {
+    const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
+    expect(ownedTitles).toEqual(['A', 'C']);
+  });
 });
 
 test('moving from owned keeps wishlist sorted', async () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [{ id: '2', title: 'A' }] });
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [{ id: '2', title: 'A' }] });
   const moveBtn = container.querySelector('.owned-item .item-menu-button');
   fireEvent.click(moveBtn);
   fireEvent.click(screen.getByText('Move'));
@@ -94,22 +134,24 @@ test('moving from owned keeps wishlist sorted', async () => {
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const wishTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
-  expect(wishTitles).toEqual(['A', 'B']);
+  await waitFor(() => {
+    const wishTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
+    expect(wishTitles).toEqual(['A', 'B']);
+  });
 });
 
-test('adding to owned keeps items sorted', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
+test('adding to owned keeps items sorted', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'B' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A' } });
   fireEvent.change(screen.getByLabelText('Target list'), { target: { value: 'owned' } });
-  fireEvent.click(screen.getByText('Add'));
+  await act(async () => { fireEvent.click(screen.getByText('Add')); });
   const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
   expect(ownedTitles).toEqual(['A', 'B']);
 });
 
-test('items in both lists get duplicate-item class', () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [{ id: '2', title: 'a' }] });
+test('items in both lists get duplicate-item class', async () => {
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [{ id: '2', title: 'a' }] });
   const wishLi = container.querySelector('.wishlist-item');
   const ownLi = container.querySelector('.owned-item');
   expect(wishLi.classList.contains('duplicate-item')).toBe(true);
@@ -117,24 +159,27 @@ test('items in both lists get duplicate-item class', () => {
 });
 
 test('duplicate add shows confirmation and adds on confirm', async () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
-  fireEvent.click(screen.getByText('Add'));
+  await act(async () => { fireEvent.click(screen.getByText('Add')); });
   expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
+  await waitFor(() => {
+    const wishItems = container.querySelectorAll('.wishlist-item span');
+    expect(wishItems.length).toBe(1);
+  });
   const wishItems = container.querySelectorAll('.wishlist-item span');
-  expect(wishItems.length).toBe(1);
   expect(wishItems[0].textContent).toBe('a');
 });
 
 test('duplicate add does not add when cancelled', async () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
-  fireEvent.click(screen.getByText('Add'));
+  await act(async () => { fireEvent.click(screen.getByText('Add')); });
   expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
   await act(async () => {
     fireEvent.click(screen.getByText('No'));
@@ -145,22 +190,24 @@ test('duplicate add does not add when cancelled', async () => {
 });
 
 test('duplicate add highlights items on confirm', async () => {
-  const { container } = renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
+  const { container } = await renderWithData({ owned: [{ id: '1', title: 'A' }], wishlist: [] });
   fireEvent.click(screen.getByLabelText('Add'));
   fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'a' } });
-  fireEvent.click(screen.getByText('Add'));
+  await act(async () => { fireEvent.click(screen.getByText('Add')); });
   expect(screen.getByText('Title already exists—add anyway?')).toBeInTheDocument();
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const wishLi = container.querySelector('.wishlist-item');
-  const ownLi = container.querySelector('.owned-item');
-  expect(wishLi.classList.contains('duplicate-item')).toBe(true);
-  expect(ownLi.classList.contains('duplicate-item')).toBe(true);
+  await waitFor(() => {
+    const wishLi = container.querySelector('.wishlist-item');
+    const ownLi = container.querySelector('.owned-item');
+    expect(wishLi.classList.contains('duplicate-item')).toBe(true);
+    expect(ownLi.classList.contains('duplicate-item')).toBe(true);
+  });
 });
 
 test('moving from wishlist keeps both lists sorted', async () => {
-  const { container } = renderWithData({
+  const { container } = await renderWithData({
     owned: [
       { id: '1', title: 'A' },
       { id: '3', title: 'C' }
@@ -177,14 +224,16 @@ test('moving from wishlist keeps both lists sorted', async () => {
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
-  const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
-  expect(ownedTitles).toEqual(['A', 'B', 'C']);
-  expect(wishlistTitles).toEqual(['D']);
+  await waitFor(() => {
+    const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
+    const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
+    expect(ownedTitles).toEqual(['A', 'B', 'C']);
+    expect(wishlistTitles).toEqual(['D']);
+  });
 });
 
 test('moving from owned keeps both lists sorted', async () => {
-  const { container } = renderWithData({
+  const { container } = await renderWithData({
     owned: [
       { id: '1', title: 'A' },
       { id: '3', title: 'C' },
@@ -202,10 +251,12 @@ test('moving from owned keeps both lists sorted', async () => {
   await act(async () => {
     fireEvent.click(screen.getByText('Yes'));
   });
-  const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
-  const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
-  expect(ownedTitles).toEqual(['A', 'E']);
-  expect(wishlistTitles).toEqual(['B', 'C', 'D']);
+  await waitFor(() => {
+    const ownedTitles = Array.from(container.querySelectorAll('.owned-item span')).map((el) => el.textContent);
+    const wishlistTitles = Array.from(container.querySelectorAll('.wishlist-item span')).map((el) => el.textContent);
+    expect(ownedTitles).toEqual(['A', 'E']);
+    expect(wishlistTitles).toEqual(['B', 'C', 'D']);
+  });
 });
 
 test('shows user from Access cookie', () => {

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,69 +1,77 @@
-import { sortTitles, addItem as computeAddItem } from './utils';
+import { sortTitles } from './utils';
 
-const KEY = 'dvdData';
-
-function normalize(list) {
-  return (list || []).map((item) =>
-    typeof item === 'string' ? { id: crypto.randomUUID(), title: item } : item
-  );
-}
-
-function loadFromLocalStorage() {
-  const cached = localStorage.getItem(KEY);
-  if (!cached) return null;
-  try {
-    const parsed = JSON.parse(cached);
-    const owned = sortTitles(normalize(parsed.owned));
-    const wishlist = sortTitles(normalize(parsed.wishlist));
-    saveToLocalStorage(owned, wishlist);
-    return { owned, wishlist };
-  } catch (err) {
-    console.error('Failed to parse cached data', err);
-    localStorage.removeItem(KEY);
-    return null;
+export async function loadCollection() {
+  const res = await fetch('/api/collection');
+  if (!res.ok) {
+    throw new Error('Failed to load collection');
   }
+  const data = await res.json();
+  return {
+    owned: sortTitles(data.owned || []),
+    wishlist: sortTitles(data.wishlist || []),
+  };
 }
 
-function saveToLocalStorage(owned, wishlist) {
-  localStorage.setItem(KEY, JSON.stringify({ owned, wishlist }));
+export async function addItem(list, title, owned, wishlist) {
+  const normalized = title.toLowerCase();
+  const duplicate =
+    owned.some((t) => t.title.toLowerCase() === normalized) ||
+    wishlist.some((t) => t.title.toLowerCase() === normalized);
+
+  const res = await fetch('/api/add', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ list, title }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to add item');
+  }
+  const { id } = await res.json();
+  const item = { id, title };
+
+  if (list === 'wishlist') {
+    return {
+      owned: [...owned],
+      wishlist: sortTitles([...wishlist, item]),
+      duplicate,
+    };
+  }
+
+  return {
+    owned: sortTitles([...owned, item]),
+    wishlist: [...wishlist],
+    duplicate,
+  };
 }
 
-export function loadCollection() {
-  const loaded = loadFromLocalStorage();
-  if (loaded) return loaded;
-  const owned = [];
-  const wishlist = [];
-  saveToLocalStorage(owned, wishlist);
-  return { owned, wishlist };
-}
+export async function moveItem(from, idx, owned, wishlist) {
+  const item = from === 'wishlist' ? wishlist[idx] : owned[idx];
+  const to = from === 'wishlist' ? 'owned' : 'wishlist';
 
-export function saveCollection(owned, wishlist) {
-  saveToLocalStorage(owned, wishlist);
-}
+  await fetch('/api/move', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: item.id, to }),
+  });
 
-export function addItem(list, title, owned, wishlist) {
-  const result = computeAddItem(list, title, owned, wishlist);
-  saveToLocalStorage(result.owned, result.wishlist);
-  return result;
-}
-
-export function moveItem(from, idx, owned, wishlist) {
   let newOwned = owned;
   let newWish = wishlist;
   if (from === 'wishlist') {
-    const item = wishlist[idx];
     newWish = sortTitles(wishlist.filter((_, i) => i !== idx));
     newOwned = sortTitles([...owned, item]);
   } else {
-    const item = owned[idx];
     newOwned = sortTitles(owned.filter((_, i) => i !== idx));
     newWish = sortTitles([...wishlist, item]);
   }
-  saveToLocalStorage(newOwned, newWish);
+
   return { owned: newOwned, wishlist: newWish };
 }
 
-export function deleteItem(list, idx, owned, wishlist) {
+export async function deleteItem(list, idx, owned, wishlist) {
+  const item = list === 'wishlist' ? wishlist[idx] : owned[idx];
+
+  await fetch(`/api/item/${item.id}`, { method: 'DELETE' });
+
   let newOwned = owned;
   let newWish = wishlist;
   if (list === 'wishlist') {
@@ -73,6 +81,5 @@ export function deleteItem(list, idx, owned, wishlist) {
   }
   newOwned = sortTitles(newOwned);
   newWish = sortTitles(newWish);
-  saveToLocalStorage(newOwned, newWish);
   return { owned: newOwned, wishlist: newWish };
 }


### PR DESCRIPTION
## Summary
- update storage layer to use worker API endpoints
- handle async storage operations in the React app
- mock fetch in tests instead of using localStorage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875a2033e08832e881918cc19e3e455