### PR TITLE
Add import endpoint with client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ npm test
 - Data is stored in a Cloudflare D1 database via the Worker.
 - Each movie is stored as an object with a unique `id` and `title`.
 
+## API
+
+### `POST /api/import`
+
+Replaces the authenticated user's collection. Send JSON of the form:
+
+```json
+{ "owned": ["Title"], "wishlist": ["Title"] }
+```
+
+The endpoint deletes any existing items for the user, adds the new ones and
+returns the saved lists with generated IDs.
+
 ## Managing Titles
 
 Each title has a **Move** button (➡️) and a **Delete** button (🗑️).

--- a/src/storage.js
+++ b/src/storage.js
@@ -83,3 +83,19 @@ export async function deleteItem(list, idx, owned, wishlist) {
   newWish = sortTitles(newWish);
   return { owned: newOwned, wishlist: newWish };
 }
+
+export async function importCollection(ownedTitles, wishlistTitles) {
+  const res = await fetch('/api/import', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ owned: ownedTitles, wishlist: wishlistTitles }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to import collection');
+  }
+  const data = await res.json();
+  return {
+    owned: sortTitles(data.owned || []),
+    wishlist: sortTitles(data.wishlist || []),
+  };
+}

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -1,4 +1,4 @@
-import { loadCollection, addItem, moveItem, deleteItem } from './storage';
+import { loadCollection, addItem, moveItem, deleteItem, importCollection } from './storage';
 
 beforeEach(() => {
   global.fetch = jest.fn();
@@ -50,4 +50,26 @@ test('deleteItem calls DELETE endpoint', async () => {
 
   expect(global.fetch).toHaveBeenCalledWith('/api/item/1', { method: 'DELETE' });
   expect(result.owned).toEqual([]);
+});
+
+test('importCollection posts to /api/import and sorts results', async () => {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        owned: [
+          { id: '2', title: 'B' },
+          { id: '1', title: 'A' },
+        ],
+        wishlist: [],
+      }),
+  });
+
+  const result = await importCollection(['B', 'A'], []);
+
+  expect(global.fetch).toHaveBeenCalledWith(
+    '/api/import',
+    expect.objectContaining({ method: 'POST' })
+  );
+  expect(result.owned.map((i) => i.title)).toEqual(['A', 'B']);
 });


### PR DESCRIPTION
## Summary
- add `/api/import` route on worker to replace a user's collection
- expose `importCollection` in storage module
- wire App import feature to call backend
- test importCollection helper
- document new API endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876958eb594832e9d3d0f89741c9b38