### PR TITLE
Fix missing IDs during import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,18 @@ import {
   importCollection,
 } from './storage';
 
+function normalize(list) {
+  return list.map((item) => {
+    if (typeof item === 'string') {
+      return { id: crypto.randomUUID(), title: item };
+    }
+    if (!item.id) {
+      return { id: crypto.randomUUID(), title: item.title };
+    }
+    return item;
+  });
+}
+
 export default function App() {
   const [owned, setOwned] = useState([]);
   const [wishlist, setWishlist] = useState([]);
@@ -145,10 +157,11 @@ export default function App() {
         if (!parsed || !Array.isArray(parsed.owned) || !Array.isArray(parsed.wishlist)) {
           throw new Error('Invalid format');
         }
-        const extract = (list) => list.map((i) => (typeof i === 'string' ? i : i.title));
+        const normalizedOwned = normalize(parsed.owned);
+        const normalizedWishlist = normalize(parsed.wishlist);
         const result = await importCollection(
-          extract(parsed.owned),
-          extract(parsed.wishlist)
+          normalizedOwned.map((i) => i.title),
+          normalizedWishlist.map((i) => i.title)
         );
         setOwned(result.owned);
         setWishlist(result.wishlist);


### PR DESCRIPTION
## Summary
- normalize imported items to ensure each has an ID
- send titles from normalized lists when importing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68769b61beb0832e8870f5b305e6fbc9